### PR TITLE
Add JPMS Automatic-Module-Name to all published artifacts

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,6 +20,10 @@
         Interface for license management on the Java Virtual Machine.
     </description>
 
+    <properties>
+        <automatic.module.name>global.namespace.truelicense.api</automatic.module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>global.namespace.fun-io</groupId>

--- a/build-tasks/pom.xml
+++ b/build-tasks/pom.xml
@@ -20,6 +20,10 @@
         string values in class files and obfuscate byte code using ProGuard.
     </description>
 
+    <properties>
+        <automatic.module.name>global.namespace.truelicense.build.tasks</automatic.module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,6 +20,10 @@
         license management.
     </description>
 
+    <properties>
+        <automatic.module.name>global.namespace.truelicense.core</automatic.module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/jax-rs/pom.xml
+++ b/jax-rs/pom.xml
@@ -20,6 +20,10 @@
         for consuming license keys.
     </description>
 
+    <properties>
+        <automatic.module.name>global.namespace.truelicense.jax.rs</automatic.module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/jsf/pom.xml
+++ b/jsf/pom.xml
@@ -21,6 +21,7 @@
     </description>
 
     <properties>
+        <automatic.module.name>global.namespace.truelicense.jsf</automatic.module.name>
         <org-netbeans-modules-projectapi.jsf_2e_language>Facelets</org-netbeans-modules-projectapi.jsf_2e_language>
     </properties>
 

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -29,6 +29,10 @@
         files.
     </description>
 
+    <properties>
+        <automatic.module.name>global.namespace.truelicense.maven.plugin</automatic.module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/obfuscate/pom.xml
+++ b/obfuscate/pom.xml
@@ -20,6 +20,10 @@
         obfuscating constant string values in Java source and class files.
     </description>
 
+    <properties>
+        <automatic.module.name>global.namespace.truelicense.obfuscate</automatic.module.name>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,9 @@
     </scm>
 
     <properties>
+        <!-- maven-jar-plugin: JPMS automatic module name; overridden per module -->
+        <automatic.module.name>global.namespace.truelicense</automatic.module.name>
+
         <!-- maven-compiler-plugin -->
         <maven.compiler.debug>false</maven.compiler.debug>
         <maven.compiler.optimize>true</maven.compiler.optimize>
@@ -343,6 +346,13 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
+                    <configuration>
+                        <archive>
+                            <manifestEntries>
+                                <Automatic-Module-Name>${automatic.module.name}</Automatic-Module-Name>
+                            </manifestEntries>
+                        </archive>
+                    </configuration>
                     <executions>
                         <execution>
                             <id>default-jar</id>

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -20,6 +20,10 @@
         Interface for license management on the Java Virtual Machine.
     </description>
 
+    <properties>
+        <automatic.module.name>global.namespace.truelicense.spi</automatic.module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/swing/pom.xml
+++ b/swing/pom.xml
@@ -20,6 +20,10 @@
         consuming license keys.
     </description>
 
+    <properties>
+        <automatic.module.name>global.namespace.truelicense.swing</automatic.module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -21,6 +21,10 @@
         wizard dialogs in particular.
     </description>
 
+    <properties>
+        <automatic.module.name>global.namespace.truelicense.ui</automatic.module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/v1/pom.xml
+++ b/v1/pom.xml
@@ -17,6 +17,10 @@
     <name>TrueLicense V1</name>
     <description>Provides the V1 license key format.</description>
 
+    <properties>
+        <automatic.module.name>global.namespace.truelicense.v1</automatic.module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/v2-core/pom.xml
+++ b/v2-core/pom.xml
@@ -17,6 +17,10 @@
     <name>TrueLicense V2 Core</name>
     <description>Provides support for the V2/* license key formats.</description>
 
+    <properties>
+        <automatic.module.name>global.namespace.truelicense.v2.core</automatic.module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/v2-json/pom.xml
+++ b/v2-json/pom.xml
@@ -17,6 +17,10 @@
     <name>TrueLicense V2/JSON</name>
     <description>Provides the V2/JSON license key format.</description>
 
+    <properties>
+        <automatic.module.name>global.namespace.truelicense.v2.json</automatic.module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/v2-xml/pom.xml
+++ b/v2-xml/pom.xml
@@ -17,6 +17,10 @@
     <name>TrueLicense V2/XML</name>
     <description>Provides the V2/XML license key format.</description>
 
+    <properties>
+        <automatic.module.name>global.namespace.truelicense.v2.xml</automatic.module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/v4/pom.xml
+++ b/v4/pom.xml
@@ -17,6 +17,10 @@
     <name>TrueLicense V4</name>
     <description>Provides the V4 license key format.</description>
 
+    <properties>
+        <automatic.module.name>global.namespace.truelicense.v4</automatic.module.name>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Give each deployed JAR a stable, well-formed JPMS module name via an Automatic-Module-Name manifest header, so the artifacts can be used on the Java module path without relying on the (unstable) name derived from the file name.

The maven-jar-plugin manifest entry is declared once in the parent POM and references ${automatic.module.name}; each module supplies that property, following its base Java package. A neutral fallback keeps the non-published tests module from emitting an unresolved value.

Resolves #41