### PR TITLE
declare plexus-utils as an explicit dependency

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -35,6 +35,15 @@
             <artifactId>truelicense-build-tasks</artifactId>
         </dependency>
 
+        <!--
+          ~ FileUtils from plexus-utils is used by GenerateSourcesMavenTask. Maven 3.9+ no longer exports
+          ~ org.codehaus.plexus.util.* from the core realm, so declare it explicitly rather than relying on maven-core.
+          -->
+        <dependency>
+            <groupId>org.codehaus.plexus</groupId>
+            <artifactId>plexus-utils</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
         <jackson.version>2.12.3</jackson.version>
         <jaxb.version>2.3.1</jaxb.version>
         <maven.version>3.8.1</maven.version>
+        <plexus-utils.version>3.5.1</plexus-utils.version>
     </properties>
 
     <modules>
@@ -296,6 +297,11 @@
                 <version>2.3</version>
             </dependency>
             <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>${plexus-utils.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.velocity.tools</groupId>
                 <artifactId>velocity-tools-generic</artifactId>
                 <version>3.1</version>
@@ -331,6 +337,17 @@
                     <artifactId>truelicense-maven-plugin</artifactId>
                     <!-- Cannot use ${project.version} while bootstrapping! -->
                     <version>4.0.3</version>
+                    <dependencies>
+                        <!--
+                          ~ Maven 3.9+ no longer exports org.codehaus.plexus.util.* from the core realm to plugins,
+                          ~ so the bootstrap plugin needs plexus-utils on its own class realm.
+                          -->
+                        <dependency>
+                            <groupId>org.codehaus.plexus</groupId>
+                            <artifactId>plexus-utils</artifactId>
+                            <version>${plexus-utils.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
Maven 3.9.0 stopped exporting org.codehaus.plexus.util.* from the core to plugins.

truelicense-maven-plugin's GenerateSourcesMavenTask uses org.codehaus.plexus.util.FileUtils but never declared a dependency on plexus-utils.

This makes usage of maven 3.9.x not possible.

Resolves #43