### PR TITLE
Fix inconsistent conversion error handling between toCharArray() and …

### DIFF
--- a/obfuscate/src/main/java/global/namespace/truelicense/obfuscate/ObfuscatedString.java.vtl
+++ b/obfuscate/src/main/java/global/namespace/truelicense/obfuscate/ObfuscatedString.java.vtl
@@ -294,7 +294,10 @@ public final class ObfuscatedString {
 
             @Override
             String decode(byte[] encoded, int length) throws Exception {
-                return new String(encoded, 0, length, charset);
+                return charset
+                        .newDecoder()
+                        .decode(ByteBuffer.wrap(encoded, 0, length))
+                        .toString();
             }
         }.call();
     }


### PR DESCRIPTION
…toString()

Let toString() use charset decoder and convert to String like the toCharArray method which has the wanted effect that conversion errors are reported via an exception. This fixes #20.